### PR TITLE
Add optional SASL support

### DIFF
--- a/AcroBot.rb
+++ b/AcroBot.rb
@@ -90,6 +90,8 @@ bot = Cinch::Bot.new do
    c.channels = settings['channels'] # ["#katello","#openshift","#satellite6","#zanata","#theforeman","#ansible"]
 #   c.channels = ["#acrobot"]
    c.prefix = settings['prefix']     # /^!/
+   c.sasl.username = settings['sasl_username'] unless settings['sasl_username'].nil?
+   c.sasl.password = ENV['SASL_PASSWORD'] unless ENV['SASL_PASSWORD'].nil?
   end
 
   on :message, /^!([\w\-\_]+)\=(.+)/ do |m, abbrev, desc|

--- a/acrobot.yaml
+++ b/acrobot.yaml
@@ -1,4 +1,5 @@
 nick: 'acrobot'
+sasl_username: 'acrobot'
 realname: IRC Acronym and Abbreviation Expander Bot. !help for help
 user: acrobot
 server: irc.freenode.net


### PR DESCRIPTION
Some networks (eg: freenode) require SASL authentication before allowing
connections from greylisted networks (eg: AWS)