### PR TITLE
Fix YAML file + add validate yaml script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ Abbreviations are initially saved to `draft.yaml`. They are later reviewed and e
 
 AcroBot must have **RW** access to `draft.yaml` and **R** access to all other dictionary files when running.
 
+YAML verification
+=================
+
+To verify that the YAML files in the project are valid, a script is provided:
+
+```
+ruby verify_yaml.rb
+```
+
+The script will return a non-zero exit code in case of failures.

--- a/data/abbrev.yaml
+++ b/data/abbrev.yaml
@@ -1429,7 +1429,7 @@ new:
   LSP: Localization Service Provider @translation
   MS: Microsoft
   JAX: Java API for XML @java
-  XPath: XML Path Language See: https://en.wikipedia.org/wiki/XPath
+  XPath: "XML Path Language See: https://en.wikipedia.org/wiki/XPath"
   IOPS: Input/Output Operations Per Second (pronounced eye-ops) @metrics https://en.wikipedia.org/wiki/IOPS
   DCO: Detailed Course Outline @training
   ISA: Instruction Set Architecture @cpu
@@ -1470,7 +1470,7 @@ new:
   JOTM: Java Open Transaction Manager @java
   2PC: Two-phase commit
   OCP: OpenShift Container Platform @openshift @do-not-use
-  PHP: PHP: Hypertext Preprocessor @no-expand
+  PHP: "PHP: Hypertext Preprocessor @no-expand"
   GbE: Gigabit Ethernet @networking
   AKI: Authority Key Identifier @auth
   MBO: Management By Objectives @mgmt

--- a/verify_yaml.rb
+++ b/verify_yaml.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+
+require 'find'
+require 'yaml'
+
+# Find all YAML files in the current folder recursively
+#
+# Returns:
+# - list<str> of files
+def get_yaml_files
+
+  yaml_files = []
+
+  Find.find('.') { |e| yaml_files << e if e.end_with?('.yaml', '.yml')}
+
+  yaml_files
+end
+
+# Verify if YAML file has valid syntax or not
+#
+# Parameters:
+# - <str: yaml file>
+#
+# Returns:
+# - List [<bool: is it valid>, <str: error message>]
+#
+#   error message is 'nil' if no errors
+def is_yaml_file_valid?(yaml_file)
+
+  begin
+    YAML.load_file(yaml_file)
+    [true, nil]
+  rescue => error
+    [false, error.message]
+  end
+end
+
+any_errors = false
+
+get_yaml_files.each do |yaml_file|
+
+  yaml_valid, error_message = is_yaml_file_valid?(yaml_file)
+
+  if yaml_valid
+    puts "YAML file '#{yaml_file}' valid!"
+  else
+    any_errors = true
+    puts ">> YAML file '#{yaml_file}' is not valid!"
+    puts ">> Error: #{error_message}"
+  end
+end
+
+# Exit with non-zero exit status if any errors
+exit(false) if any_errors


### PR DESCRIPTION
# Fix abbrev.yaml file format

YAML gets confused with the '<text>: <other text>' in the value of those
keys. We need to properly quote them so that YAML knows it's all a
string

#  Add validation YAML script to verify YAML files

To run the script:

```
ruby verify_yaml.rb
```

A sample output is:
```
$ ruby verify_yaml.rb
YAML file './acrobot.yaml' valid!
YAML file './data/abbrev.yaml' valid!
YAML file './data/draft.yaml' valid!
```

In case of failure, the script will point out the non-valid YAML file
and the reason:

```
$ ruby verify_yaml.rb
>> YAML file './acrobot.yaml' is not valid!
>> Error: (./acrobot.yaml): could not find expected ':' while scanning a simple key at line 8 column 1
YAML file './data/abbrev.yaml' valid!
YAML file './data/draft.yaml' valid!
```

In addition, the script will terminate with a non-zero exit code.