### PR TITLE
Update Ruby version to latest 2.x series

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:2
 
 RUN apt-get -qq update && \
     apt-get -qq -y install rsync && \


### PR DESCRIPTION
There are some changes introduced in Ruby 3.x (latest) which breaks cinch:
```
/usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger.rb:118:in `encode': no implicit conversion of Hash into String (TypeError)
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger.rb:118:in `block (2 levels) in log'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger.rb:113:in `each'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger.rb:113:in `block in log'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger.rb:112:in `synchronize'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger.rb:112:in `log'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger.rb:35:in `debug'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger_list.rb:36:in `block in debug'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger_list.rb:36:in `each'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/logger_list.rb:36:in `debug'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/handler_list.rb:17:in `block in register'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/handler_list.rb:16:in `synchronize'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/handler_list.rb:16:in `register'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/bot.rb:204:in `on'
	from ./AcroBot.rb:118:in `block in <main>'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/bot.rb:355:in `instance_eval'
	from /usr/local/bundle/gems/cinch-2.3.4/lib/cinch/bot.rb:355:in `initialize'
	from ./AcroBot.rb:91:in `new'
	from ./AcroBot.rb:91:in `<main>'
```

However, reverting it back to latest Ruby 2.x make cinch happy. Since crinch is no more maintained, I think this is a valid solution as a workaround.